### PR TITLE
Fix up commands and simplify book/review edit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -18,18 +18,14 @@ This separation allows you to:
 
 Libro's commands are organized around this book/review separation:
 
-**Default Views (Table Format):**
+**Reports:**
 - `libro` (default) - Reading history table
 - `libro report` - Reading history table  
-- `libro report --author` - Author statistics table
-
-**Chart Views:**
+- `libro report --author` - Book counts by author
 - `libro report --chart` - Yearly reading chart
+- `libro report 123` - Book/review details for review id
 
-**Detail Views:**
-- `libro report 123` - Book/review details
-
-**Other Commands:**
+**Actions:**
 - `libro add` - Add book + review
 - `libro book` - Book management (add, edit, show)
 - `libro review` - Review management (add, edit, show)
@@ -37,17 +33,8 @@ Libro's commands are organized around this book/review separation:
 
 ## Usage
 
-### Quick Start Commands
+**Add books and review:**: `libro add`
 
-**View your reading history:**
-- Current year: `libro` or `libro report`
-- Specific year: `libro report --year 2024`
-- By author: `libro report --author "Stephen King"`
-- Yearly chart: `libro report --chart`
-
-**Add books and reviews:**
-- Add book + review: `libro add`
-- Book details: `libro report 123`
 
 ### Book Management
 
@@ -69,13 +56,7 @@ Show specific review: `libro review show 123`
 
 Edit review details only: `libro review edit 123`
 
-### Reports
-
-Show reading charts by year: `libro report --chart`
-
-Show books read grouped by author: `libro report --author`
-
-**Reading Lists:**
+### Reading Lists
 
 Create a reading list: `libro list create "My Reading List" --description "Books to read"`
 
@@ -91,7 +72,7 @@ See: `libro --help` for more information.
 
 #### Books Read in Year
 
-The default view shows your reading history. The ID column shows Review IDs, which you can use with `libro review edit <id>` and `libro report <id>`:
+The default view shows your reading history, grouped by genre:
 
 ```
 ❯ libro
@@ -185,13 +166,13 @@ View all your reading lists:
 ❯ libro list show
 
                                     Reading Lists
-┏━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┓
-┃ ID ┃ Name               ┃ Description                      ┃ Total Books ┃ Read ┃ Unread ┃ Progress             ┃ Created    ┃
-┡━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━┩
-│ 1  │ Sci-Fi Classics    │ Science fiction must-reads       │ 50          │ 12   │ 38     │ ██░░░░░░░░ 24.0%     │ 2025-01-15 │
-│ 2  │ Horror Collection  │ Spine-tingling tales             │ 30          │ 8    │ 22     │ ███░░░░░░░ 26.7%     │ 2025-01-16 │
-│ 3  │ Literary Classics  │ Timeless masterpieces            │ 45          │ 15   │ 30     │ ███░░░░░░░ 33.3%     │ 2025-01-17 │
-└────┴────────────────────┴──────────────────────────────────┴─────────────┴──────┴────────┴───────────────────────┴────────────┘
+┏━━━━┳━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━━━━━┓
+┃ ID ┃ Name               ┃ Description                      ┃ Total Books ┃ Read ┃ Unread ┃ Progress         ┃
+┡━━━━╇━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━━━━━┩
+│ 1  │ Sci-Fi Classics    │ Science fiction must-reads       │ 50          │ 12   │ 38     │ ██░░░░░░░░ 24.0% │
+│ 2  │ Horror Collection  │ Spine-tingling tales             │ 30          │ 8    │ 22     │ ███░░░░░░░ 26.7% │
+│ 3  │ Literary Classics  │ Timeless masterpieces            │ 45          │ 15   │ 30     │ ███░░░░░░░ 33.3% │
+└────┴────────────────────┴──────────────────────────────────┴─────────────┴──────┴────────┴──────────────────┘
 
 Use 'libro list show <id>' to see books in a specific list
 ```
@@ -373,25 +354,3 @@ There is a `genre` field that accepts any string value, but this data is not ava
 
 See [GitHub Releases](https://github.com/mkaz/libro/releases) for the changelog.
 
-# Packaging
-
-Notes to self, I forget how to do this stuff.
-
-Libro is packaged as `libro-book` on PyPI.
-
-Packaging is done with `hatchling`, [see Guide](https://packaging.python.org/en/latest/tutorials/packaging-projects/)
-
-```
-# install tools
-py -m pip install --upgrade build twine
-```
-
-```
-# build
-py -m build
-```
-
-```
-# upload
-py -m twine upload dist/*
-```

--- a/readme.md
+++ b/readme.md
@@ -14,19 +14,40 @@ This separation allows you to:
 - Add multiple reviews for the same book (re-reads)
 - Maintain a clean library of books separate from your reading history
 
+## Command Structure
+
+Libro's commands are organized around this book/review separation:
+
+**Default Views (Table Format):**
+- `libro` (default) - Reading history table
+- `libro report` - Reading history table  
+- `libro report --author` - Author statistics table
+
+**Chart Views:**
+- `libro report --chart` - Yearly reading chart
+
+**Detail Views:**
+- `libro report 123` - Book/review details
+
+**Other Commands:**
+- `libro add` - Add book + review
+- `libro book` - Book management (add, edit, show)
+- `libro review` - Review management (add, edit, show)
+- `libro list` - Reading list management
+
 ## Usage
 
 ### Quick Start Commands
 
-Add new book with review: `libro add`
+**View your reading history:**
+- Current year: `libro` or `libro report`
+- Specific year: `libro report --year 2024`
+- By author: `libro report --author "Stephen King"`
+- Yearly chart: `libro report --chart`
 
-Show books read this year: `libro show` (or `libro show --year 2024`)
-
-Show book & review details: `libro show 123`
-
-Show books by author: `libro show --author "Stephen King"`
-
-Edit book & review: `libro edit 123`
+**Add books and reviews:**
+- Add book + review: `libro add`
+- Book details: `libro report 123`
 
 ### Book Management
 
@@ -38,7 +59,7 @@ Show book by author: `libro book show --author "Stephen King"`
 
 Show specific book: `libro book show 42`
 
-Edit book details: `libro book edit 42`
+Edit book details only: `libro book edit 42`
 
 ### Review Management
 
@@ -46,11 +67,11 @@ Add review to existing book: `libro review add 42`
 
 Show specific review: `libro review show 123`
 
-Edit review: `libro review edit 123`
+Edit review details only: `libro review edit 123`
 
 ### Reports
 
-Show reading reports: `libro report`
+Show reading charts by year: `libro report --chart`
 
 Show books read grouped by author: `libro report --author`
 
@@ -70,7 +91,7 @@ See: `libro --help` for more information.
 
 #### Books Read in Year
 
-The default view shows your reading history with Review IDs for easy editing:
+The default view shows your reading history. The ID column shows Review IDs, which you can use with `libro review edit <id>` and `libro report <id>`:
 
 ```
 ❯ libro
@@ -100,10 +121,10 @@ The default view shows your reading history with Review IDs for easy editing:
 ```
 
 
-#### Books by Year
+#### Books by Year Chart
 
 ```
-❯ libro report
+❯ libro report --chart
 
                          Books Read by Year
 

--- a/src/libro/actions/modify.py
+++ b/src/libro/actions/modify.py
@@ -110,7 +110,7 @@ style = Style.from_dict(
 )
 
 
-def add_book(db, args):
+def add_book_review(db, args):
     session = PromptSession(style=style)
     console = Console()
 
@@ -186,7 +186,7 @@ def add_book(db, args):
         print(f"Error: {e}")
 
 
-def add_book_only(db, args):
+def add_book(db, args):
     """Add a book without a review."""
     session = PromptSession(style=style)
     console = Console()
@@ -236,7 +236,7 @@ def add_book_only(db, args):
         print(f"Error: {e}")
 
 
-def add_review_only(db, args):
+def add_review(db, args):
     """Add a review to an existing book."""
     book_id = args["book_id"]
     session = PromptSession(style=style)
@@ -294,124 +294,7 @@ def add_review_only(db, args):
         print(f"Error: {e}")
 
 
-def edit_book_by_book_id(db, args):
-    """Edit a book using book ID - finds the most recent review."""
-    book_id = int(args["id"])
-    
-    # Check if book exists
-    cursor = db.cursor()
-    cursor.execute("SELECT title, author FROM books WHERE id = ?", (book_id,))
-    book_info = cursor.fetchone()
-    
-    if not book_info:
-        print(f"Error: Book with ID {book_id} not found.")
-        return
-        
-    # Find the most recent review for this book
-    cursor.execute("""
-        SELECT r.id FROM reviews r 
-        WHERE r.book_id = ? 
-        ORDER BY r.date_read DESC, r.id DESC 
-        LIMIT 1
-    """, (book_id,))
-    review_row = cursor.fetchone()
-    
-    if not review_row:
-        print(f"Error: No reviews found for book '{book_info['title']}' (Book ID: {book_id})")
-        print("Use 'libro review add {book_id}' to add a review first.")
-        return
-        
-    # Use the existing edit function with the review ID
-    args["id"] = review_row["id"]
-    edit_book(db, args)
 
-
-def edit_book(db, args):
-    """Edit a book/review using review ID (backward compatibility)."""
-    review_id = int(args["id"])
-    book_review = BookReview.get_by_id(db, review_id)
-    if not book_review:
-        print(f"Error: Review with ID {review_id} not found.")
-        return
-
-    session = PromptSession(style=style)
-    console = Console()
-
-    try:
-        updated_book_data = {}
-        updated_review_data = {}
-
-        # --- Book Fields ---
-        console.print("BOOK DETAILS:\n---------------\n", style="blue")
-
-        # Title and Author (no conversion needed)
-        updated_book_data["title"] = _update_field(
-            session, book_review.book_title, "Title: ", validator=NonEmptyValidator()
-        )
-
-        updated_book_data["author"] = _update_field(
-            session, book_review.book_author, "Author: ", validator=NonEmptyValidator(), completer=AuthorCompleter(db)
-        )
-
-        # Publication year (integer conversion)
-        updated_book_data["pub_year"] = _update_field(
-            session,
-            book_review.book_pub_year,
-            "Publication year: ",
-            IntValidator(),
-            _convert_to_int_or_none,
-        )
-
-        # Pages (integer conversion)
-        updated_book_data["pages"] = _update_field(
-            session,
-            book_review.book_pages,
-            "Number of pages: ",
-            IntValidator(),
-            _convert_to_int_or_none,
-        )
-
-        # Genre (lowercase conversion)
-        updated_book_data["genre"] = _update_field(
-            session,
-            book_review.book_genre,
-            "Genre: ",
-            GenreValidator(),
-            _convert_genre_to_lowercase,
-            completer=GenreCompleter(db)
-        )
-
-        # --- Review Fields ---
-        console.print("\nYOUR REVIEW DETAILS:\n-------------------\n", style="blue")
-
-        # Date read (string conversion, stored as string)
-        updated_review_data["date_read"] = _update_field(
-            session, book_review.date_read, "Date read (YYYY-MM-DD): ", DateValidator()
-        )
-
-        # Rating (integer conversion)
-        updated_review_data["rating"] = _update_field(
-            session,
-            book_review.rating,
-            "Rating (1-5): ",
-            RatingValidator(),
-            _convert_to_int_or_none,
-        )
-
-        # Review text (multiline)
-        updated_review_data["review"] = _update_field(
-            session,
-            book_review.review_text,
-            "Your review (Esc+Enter to finish):\n",
-            multiline=True,
-        )
-
-        # Update database
-        _update_database(db, updated_book_data, updated_review_data, book_review)
-
-    except KeyboardInterrupt:
-        print("\n\nEdit cancelled. No changes made.")
-        return
 
 
 def _prompt_with_retry(
@@ -457,8 +340,76 @@ def _update_field(
     return new_value if new_value != current_value else None
 
 
-def _update_database(db, updated_book_data, updated_review_data, book_review):
-    """Handle the database update operations."""
+
+
+def edit_book(db, args):
+    """Edit only the book data."""
+    book_id = int(args["id"])
+    
+    # Check if book exists and get current data
+    cursor = db.cursor()
+    cursor.execute("SELECT * FROM books WHERE id = ?", (book_id,))
+    book_row = cursor.fetchone()
+    
+    if not book_row:
+        print(f"Error: Book with ID {book_id} not found.")
+        return
+
+    session = PromptSession(style=style)
+    console = Console()
+
+    try:
+        console.print(f"EDITING BOOK ID {book_id}:\n------------------------\n", style="blue")
+
+        updated_book_data = {}
+
+        # Title and Author (no conversion needed)
+        updated_book_data["title"] = _update_field(
+            session, book_row["title"], "Title: ", validator=NonEmptyValidator()
+        )
+
+        updated_book_data["author"] = _update_field(
+            session, book_row["author"], "Author: ", validator=NonEmptyValidator(), completer=AuthorCompleter(db)
+        )
+
+        # Publication year (integer conversion)
+        updated_book_data["pub_year"] = _update_field(
+            session,
+            book_row["pub_year"],
+            "Publication year: ",
+            IntValidator(),
+            _convert_to_int_or_none,
+        )
+
+        # Pages (integer conversion)
+        updated_book_data["pages"] = _update_field(
+            session,
+            book_row["pages"],
+            "Number of pages: ",
+            IntValidator(),
+            _convert_to_int_or_none,
+        )
+
+        # Genre (lowercase conversion)
+        updated_book_data["genre"] = _update_field(
+            session,
+            book_row["genre"],
+            "Genre: ",
+            GenreValidator(),
+            _convert_genre_to_lowercase,
+            completer=GenreCompleter(db)
+        )
+
+        # Update database (only book data)
+        _update_book_database(db, updated_book_data, book_id)
+
+    except KeyboardInterrupt:
+        print("\n\nEdit cancelled. No changes made.")
+        return
+
+
+def _update_book_database(db, updated_book_data, book_id):
+    """Handle the database update operations for book-only edits."""
     try:
         cursor = db.cursor()
 
@@ -466,25 +417,96 @@ def _update_database(db, updated_book_data, updated_review_data, book_review):
         filtered_book_data = {
             k: v for k, v in updated_book_data.items() if v is not None
         }
-        filtered_review_data = {
-            k: v for k, v in updated_review_data.items() if v is not None
-        }
 
         if filtered_book_data:
-            # Construct UPDATE query for books table
+            # Construct UPDATE query for books table only
             book_update_query = (
                 "UPDATE books SET "
                 + ", ".join([f"{key} = ?" for key in filtered_book_data.keys()])
                 + " WHERE id = ?"
             )
-            book_update_values = list(filtered_book_data.values()) + [
-                book_review.book_id
-            ]
+            book_update_values = list(filtered_book_data.values()) + [book_id]
             cursor.execute(book_update_query, book_update_values)
-            print(f"Updated book with ID {book_review.book_id}.")
+            print(f"Updated book with ID {book_id}.")
+            db.commit()
+        else:
+            print("\nNo changes made.")
+
+    except sqlite3.Error as e:
+        print(f"Database error: {e}")
+        db.rollback()
+    except Exception as e:
+        print(f"Error during update: {e}")
+        db.rollback()
+
+
+def edit_review(db, args):
+    """Edit only the review data, display book data for context."""
+    review_id = int(args["id"])
+    book_review = BookReview.get_by_id(db, review_id)
+    if not book_review:
+        print(f"Error: Review with ID {review_id} not found.")
+        return
+
+    session = PromptSession(style=style)
+    console = Console()
+
+    try:
+        # Display book information for context (read-only)
+        console.print(f"BOOK ID {book_review.book_id}:\n-------------------------\n", style="dim")
+        console.print(f"Title: {book_review.book_title}", style="dim")
+        console.print(f"Author: {book_review.book_author}", style="dim")
+        console.print(f"Publication Year: {book_review.book_pub_year or 'N/A'}", style="dim")
+        console.print(f"Pages: {book_review.book_pages or 'N/A'}", style="dim")
+        console.print(f"Genre: {book_review.book_genre or 'N/A'}", style="dim")
+
+        # Edit only review fields
+        console.print("\nEDIT REVIEW:\n-------------------------\n", style="blue")
+
+        updated_review_data = {}
+
+        # Date read (string conversion, stored as string)
+        updated_review_data["date_read"] = _update_field(
+            session, book_review.date_read, "Date read (YYYY-MM-DD): ", DateValidator()
+        )
+
+        # Rating (integer conversion)
+        updated_review_data["rating"] = _update_field(
+            session,
+            book_review.rating,
+            "Rating (1-5): ",
+            RatingValidator(),
+            _convert_to_int_or_none,
+        )
+
+        # Review text (multiline)
+        updated_review_data["review"] = _update_field(
+            session,
+            book_review.review_text,
+            "Your review (Esc+Enter to finish):\n",
+            multiline=True,
+        )
+
+        # Update database (only review data)
+        _update_review_database(db, updated_review_data, book_review)
+
+    except KeyboardInterrupt:
+        print("\n\nEdit cancelled. No changes made.")
+        return
+
+
+def _update_review_database(db, updated_review_data, book_review):
+    """Handle the database update operations for review-only edits."""
+    try:
+        cursor = db.cursor()
+
+        # Filter out None values (unchanged fields)
+        filtered_review_data = {
+            k: v for k, v in updated_review_data.items() if v is not None
+        }
 
         if filtered_review_data:
-            # Construct UPDATE query for reviews table
+            # Construct UPDATE query for reviews table only
             review_update_query = (
                 "UPDATE reviews SET "
                 + ", ".join([f"{key} = ?" for key in filtered_review_data.keys()])
@@ -495,8 +517,6 @@ def _update_database(db, updated_book_data, updated_review_data, book_review):
             ]
             cursor.execute(review_update_query, review_update_values)
             print(f"Updated review with ID {book_review.review_id}.")
-
-        if filtered_book_data or filtered_review_data:
             db.commit()
         else:
             print("\nNo changes made.")

--- a/src/libro/actions/report.py
+++ b/src/libro/actions/report.py
@@ -4,14 +4,28 @@ import sqlite3
 from rich.console import Console
 from rich.table import Table
 from rich import box
+from libro.actions.show import show_books, show_book_detail
 
 
 def report(db, args):
     """Main report function that routes to specific report types based on args."""
+    # if id is not none, show book detail (same as old show command)
+    if args.get("id") is not None:
+        show_book_detail(db, args.get("id"))
+        return
+    
+    # Check for author flag - show author report (table format)
     if args.get("author") is True:
         show_author_report(db, args)
-    else:
+        return
+    
+    # Check for chart flag - show year chart view
+    if args.get("chart") is True:
         show_year_report(db)
+        return
+    
+    # Default behavior: show table view (same as old show_books)
+    show_books(db, args)
 
 
 def get_books_by_year(db):

--- a/src/libro/config.py
+++ b/src/libro/config.py
@@ -35,9 +35,6 @@ def init_args() -> Dict:
     # Add command with its specific arguments (backward compatibility - creates book + review)
     subparsers.add_parser("add", help="Add a book with review")
 
-    # Edit command with its specific arguments  
-    edit = subparsers.add_parser("edit", help="Edit a book & review (use ID from default listing)")
-    edit.add_argument("id", type=int, nargs="?", help="Review ID to edit (from default listing)")
 
     # Book management subcommands
     book_parser = subparsers.add_parser("book", help="Manage books")

--- a/src/libro/config.py
+++ b/src/libro/config.py
@@ -22,15 +22,13 @@ def init_args() -> Dict:
 
     # Report command with its specific arguments
     report = subparsers.add_parser("report", help="Show reports")
+    report.add_argument("--chart", action="store_true", help="Show chart view of books by year")
     report.add_argument("--author", action="store_true", help="Show author report")
     report.add_argument("--limit", type=int, help="Minimum books read by author")
     report.add_argument("--undated", action="store_true", help="Include undated books")
+    report.add_argument("--year", type=int, help="Year to filter books")
+    report.add_argument("id", type=int, nargs="?", help="Show book ID details")
 
-    # Show command with its specific arguments
-    show = subparsers.add_parser("show", help="Show books")
-    show.add_argument("--year", type=int, help="Year to filter books")
-    show.add_argument("--author", type=str, help="Show books by specific author")
-    show.add_argument("id", type=int, nargs="?", help="Show book ID details")
 
     # Add command with its specific arguments (backward compatibility - creates book + review)
     subparsers.add_parser("add", help="Add a book with review")
@@ -135,7 +133,7 @@ def init_args() -> Dict:
         args["db"] = get_db_loc()
 
     if args["command"] is None:
-        args["command"] = "show"
+        args["command"] = "report"
 
     if args.get("year") is None:
         args["year"] = datetime.now().year

--- a/src/libro/main.py
+++ b/src/libro/main.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 
 from libro.config import init_args
-from libro.actions.show import show_books, show_book_detail, show_books_only
+from libro.actions.show import show_book_detail, show_books_only
 from libro.actions.report import report
 from libro.actions.modify import add_book_review, add_book, add_review, edit_book, edit_review
 from libro.actions.db import init_db, migrate_db
@@ -42,8 +42,6 @@ def main():
         match args["command"]:
             case "add":
                 add_book_review(db, args)
-            case "show":
-                show_books(db, args)
             case "report":
                 report(db, args)
             case "import":

--- a/src/libro/main.py
+++ b/src/libro/main.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from libro.config import init_args
 from libro.actions.show import show_books, show_book_detail, show_books_only
 from libro.actions.report import report
-from libro.actions.modify import add_book, edit_book, add_book_only, add_review_only, edit_book_by_book_id
+from libro.actions.modify import add_book_review, add_book, add_review, edit_book, edit_review
 from libro.actions.db import init_db, migrate_db
 from libro.actions.importer import import_books
 from libro.actions.lists import manage_lists
@@ -41,9 +41,7 @@ def main():
 
         match args["command"]:
             case "add":
-                add_book(db, args)
-            case "edit":
-                edit_book(db, args)  # Works with review IDs from default listing
+                add_book_review(db, args)
             case "show":
                 show_books(db, args)
             case "report":
@@ -60,9 +58,9 @@ def main():
                 else:
                     match book_action:
                         case "add":
-                            add_book_only(db, args)
+                            add_book(db, args)
                         case "edit":
-                            edit_book_by_book_id(db, args)  # Edit book by book ID
+                            edit_book(db, args)
                         case "show":
                             show_books_only(db, args)
                         case _:
@@ -75,9 +73,9 @@ def main():
                 else:
                     match review_action:
                         case "add":
-                            add_review_only(db, args)
+                            add_review(db, args)
                         case "edit":
-                            edit_book(db, args)  # Will update this for review editing
+                            edit_review(db, args)
                         case "show":
                             if args.get("id"):
                                 show_book_detail(db, args["id"])  # Same as default show


### PR DESCRIPTION
The book and review editing got mixed up trying to make things convenient.
This PR simplifies it back, there is one convenience function to add a book and review at the same time, this removes the function to edit a book and review at the same time.

The other functions all operate independent: 
* `book add` and `book edit` should only add and edit books
* `review add` and `review edit` should only add and edit reviews