### PR TITLE
Simplify CLI and improve consistency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,14 +21,15 @@ Libro's commands are organized around this book/review separation:
 **Reports:**
 - `libro` (default) - Reading history table
 - `libro report` - Reading history table  
-- `libro report --author` - Book counts by author
+- `libro report --author` - Author statistics (most read authors)
+- `libro report --author "Name"` - Books/reviews by specific author  
 - `libro report --chart` - Yearly reading chart
 - `libro report 123` - Book/review details for review id
 
 **Actions:**
 - `libro add` - Add book + review
-- `libro book` - Book management (add, edit, show)
-- `libro review` - Review management (add, edit, show)
+- `libro book` - Book management (show, add, edit)
+- `libro review` - Review management (show, add, edit)
 - `libro list` - Reading list management
 
 ## Usage
@@ -40,30 +41,42 @@ Libro's commands are organized around this book/review separation:
 
 Add book only (no review): `libro book add`
 
-Show recent books: `libro book show` (shows latest 20 books by default)
+Show recent books: `libro book` (shows latest 20 books by default)
 
-Show specific book: `libro book show 42`
+Show specific book: `libro book 42`
 
 Edit book details only: `libro book edit 42`
 
 **Search and filter books:**
 
-Show books by author: `libro book show --author "Stephen King"`
+Show books by author: `libro book --author "Stephen King"`
 
-Show books by title: `libro book show --title "Foundation"`
+Show books by title: `libro book --title "Foundation"`
 
-Show books published in specific year: `libro book show --year 2024`
+Show books published in specific year: `libro book --year 2024`
 
 All search options support partial matching, so `--author "King"` will find "Stephen King", "Tabitha King", etc.
 
 
 ### Review Management
 
+Show recent reviews: `libro review` (shows latest 20 reviews by default)
+
+Show specific review: `libro review 123`
+
 Add review to existing book: `libro review add 42`
 
-Show specific review: `libro review show 123`
-
 Edit review details only: `libro review edit 123`
+
+**Search and filter reviews:**
+
+Show reviews by author: `libro review --author "Stephen King"` (searches book authors)
+
+Show reviews by book title: `libro review --title "Foundation"` (searches book titles)
+
+Show reviews from specific year: `libro review --year 2024` (searches by date_read)
+
+All search options support partial matching, and year filtering uses the date the review was made, not the book's publication year.
 
 ### Reading Lists
 
@@ -135,8 +148,9 @@ The default view shows your reading history, grouped by genre:
   2025   17      ▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄
 ```
 
-#### Author Report
+#### Author Report and Filtering
 
+Show author statistics (most read authors):
 ```
 ❯ libro report --author
 
@@ -157,6 +171,19 @@ The default view shows your reading history, grouped by genre:
   Natalie D. Richards   3
   Lucy Foley            3
   Cory Doctorow         3
+```
+
+Show books/reviews by specific author:
+```
+❯ libro report --author "Stephen King"
+
+                                Books by Stephen King
+┏━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━┳━━━━━━━━━━━━━━┓
+┃ ID ┃ Title                        ┃ Author        ┃ Rating ┃ Date Read    ┃
+┡━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━╇━━━━━━━━━━━━━━┩
+│ 1  │ Cujo                         │ Stephen King  │ 3      │ Jan 05, 2025 │
+│ 584│ Salem's Lot                  │ Stephen King  │ 3      │ Mar 12, 2025 │
+└────┴──────────────────────────────┴───────────────┴────────┴──────────────┘
 ```
 
 ## Reading Lists

--- a/src/libro/actions/report.py
+++ b/src/libro/actions/report.py
@@ -14,9 +14,15 @@ def report(db, args):
         show_book_detail(db, args.get("id"))
         return
     
-    # Check for author flag - show author report (table format)
-    if args.get("author") is True:
-        show_author_report(db, args)
+    # Check for author flag - show author statistics if True, or books by author if string
+    author_arg = args.get("author")
+    if author_arg is not None:
+        if author_arg is True:
+            # --author flag without value: show author statistics
+            show_author_report(db, args)
+        else:
+            # --author with value: show books by specific author
+            show_books(db, args)
         return
     
     # Check for chart flag - show year chart view

--- a/src/libro/actions/show.py
+++ b/src/libro/actions/show.py
@@ -346,3 +346,60 @@ def get_reviews(db, year=None, author_name=None):
     except Exception as e:
         print(f"Error: {e}")
         return None
+
+
+def show_recent_reviews(db):
+    """Show recent reviews (latest 20)"""
+    try:
+        cursor = db.cursor()
+        cursor.execute(
+            """
+            SELECT r.id as review_id, b.title, b.author, b.genre, r.rating, r.date_read
+            FROM reviews r
+            JOIN books b ON r.book_id = b.id
+            ORDER BY r.id DESC
+            LIMIT 20
+            """
+        )
+        reviews = cursor.fetchall()
+        
+        if not reviews:
+            print("No reviews found.")
+            return
+
+        console = Console()
+        table = Table(show_header=True, title="Recent Reviews (Latest 20)")
+        table.add_column("Review ID")
+        table.add_column("Title")
+        table.add_column("Author")
+        table.add_column("Genre")
+        table.add_column("Rating")
+        table.add_column("Date Read")
+
+        for review in reviews:
+            # Format the date
+            date_str = review["date_read"]
+            if date_str:
+                try:
+                    date_obj = datetime.strptime(date_str, "%Y-%m-%d")
+                    formatted_date = date_obj.strftime("%b %d, %Y")
+                except ValueError:
+                    formatted_date = date_str
+            else:
+                formatted_date = "Not set"
+
+            table.add_row(
+                str(review["review_id"]),
+                review["title"],
+                review["author"],
+                review["genre"] or "Not set",
+                str(review["rating"]) if review["rating"] else "Not rated",
+                formatted_date,
+            )
+
+        console.print(table)
+        
+    except sqlite3.Error as e:
+        print(f"Database error: {e}")
+    except Exception as e:
+        print(f"Error: {e}")

--- a/src/libro/actions/show.py
+++ b/src/libro/actions/show.py
@@ -348,19 +348,64 @@ def get_reviews(db, year=None, author_name=None):
         return None
 
 
-def show_recent_reviews(db):
-    """Show recent reviews (latest 20)"""
+def show_recent_reviews(db, args={}):
+    """Show recent reviews (latest 20) or filtered reviews"""
     try:
         cursor = db.cursor()
-        cursor.execute(
-            """
-            SELECT r.id as review_id, b.title, b.author, b.genre, r.rating, r.date_read
-            FROM reviews r
-            JOIN books b ON r.book_id = b.id
-            ORDER BY r.id DESC
-            LIMIT 20
-            """
-        )
+        
+        # Check for filtering options
+        author = args.get("author")
+        title = args.get("title") 
+        year = args.get("year")
+        
+        if author:
+            cursor.execute(
+                """
+                SELECT r.id as review_id, b.title, b.author, b.genre, r.rating, r.date_read
+                FROM reviews r
+                JOIN books b ON r.book_id = b.id
+                WHERE LOWER(b.author) LIKE LOWER(?)
+                ORDER BY r.date_read DESC
+                """,
+                (f"%{author}%",),
+            )
+            table_title = f"Reviews by {author}"
+        elif title:
+            cursor.execute(
+                """
+                SELECT r.id as review_id, b.title, b.author, b.genre, r.rating, r.date_read
+                FROM reviews r
+                JOIN books b ON r.book_id = b.id
+                WHERE LOWER(b.title) LIKE LOWER(?)
+                ORDER BY r.date_read DESC
+                """,
+                (f"%{title}%",),
+            )
+            table_title = f"Reviews for books with title containing '{title}'"
+        elif year:
+            cursor.execute(
+                """
+                SELECT r.id as review_id, b.title, b.author, b.genre, r.rating, r.date_read
+                FROM reviews r
+                JOIN books b ON r.book_id = b.id
+                WHERE strftime('%Y', r.date_read) = ?
+                ORDER BY r.date_read DESC
+                """,
+                (str(year),),
+            )
+            table_title = f"Reviews from {year}"
+        else:
+            cursor.execute(
+                """
+                SELECT r.id as review_id, b.title, b.author, b.genre, r.rating, r.date_read
+                FROM reviews r
+                JOIN books b ON r.book_id = b.id
+                ORDER BY r.id DESC
+                LIMIT 20
+                """
+            )
+            table_title = "Recent Reviews (Latest 20)"
+            
         reviews = cursor.fetchall()
         
         if not reviews:
@@ -368,7 +413,7 @@ def show_recent_reviews(db):
             return
 
         console = Console()
-        table = Table(show_header=True, title="Recent Reviews (Latest 20)")
+        table = Table(show_header=True, title=table_title)
         table.add_column("Review ID")
         table.add_column("Title")
         table.add_column("Author")

--- a/src/libro/config.py
+++ b/src/libro/config.py
@@ -46,6 +46,9 @@ def init_args() -> Dict:
     review_parser = subparsers.add_parser("review", help="Manage reviews")
     review_parser.add_argument("action_or_id", nargs="?", help="Review ID to show, 'add' to add review, or 'edit' to edit review")
     review_parser.add_argument("target_id", type=int, nargs="?", help="Book ID to add review to (when action is 'add') or Review ID to edit (when action is 'edit')")
+    review_parser.add_argument("--author", type=str, help="Show reviews by specific author (from book details)")
+    review_parser.add_argument("--year", type=int, help="Year reviews were made (date_read)")
+    review_parser.add_argument("--title", type=str, help="Show reviews by book title (partial match)")
 
     # Import command with its specific arguments
     imp = subparsers.add_parser("import", help="Import books")

--- a/src/libro/config.py
+++ b/src/libro/config.py
@@ -23,7 +23,7 @@ def init_args() -> Dict:
     # Report command with its specific arguments
     report = subparsers.add_parser("report", help="Show reports")
     report.add_argument("--chart", action="store_true", help="Show chart view of books by year")
-    report.add_argument("--author", action="store_true", help="Show author report")
+    report.add_argument("--author", nargs="?", const=True, help="Show author statistics if no name provided, or books by specific author")
     report.add_argument("--limit", type=int, help="Minimum books read by author")
     report.add_argument("--undated", action="store_true", help="Include undated books")
     report.add_argument("--year", type=int, help="Year to filter books")
@@ -54,6 +54,7 @@ def init_args() -> Dict:
 
     # Review management subcommands
     review_parser = subparsers.add_parser("review", help="Manage reviews")
+    review_parser.add_argument("id", type=int, nargs="?", help="Review ID to show (when no subcommand specified)")
     review_subparsers = review_parser.add_subparsers(dest="review_action", help="Review actions")
     
     # Review add subcommand

--- a/src/libro/config.py
+++ b/src/libro/config.py
@@ -34,40 +34,18 @@ def init_args() -> Dict:
     subparsers.add_parser("add", help="Add a book with review")
 
 
-    # Book management subcommands
+    # Book management command
     book_parser = subparsers.add_parser("book", help="Manage books")
-    book_subparsers = book_parser.add_subparsers(dest="book_action", help="Book actions")
-    
-    # Book add subcommand
-    book_subparsers.add_parser("add", help="Add a book (without review)")
-    
-    # Book edit subcommand
-    book_edit_parser = book_subparsers.add_parser("edit", help="Edit book details")
-    book_edit_parser.add_argument("id", type=int, help="Book ID to edit")
-    
-    # Book show subcommand
-    book_show_parser = book_subparsers.add_parser("show", help="Show books")
-    book_show_parser.add_argument("id", type=int, nargs="?", help="Show specific book ID")
-    book_show_parser.add_argument("--author", type=str, help="Show books by specific author")
-    book_show_parser.add_argument("--year", type=int, help="Year to filter books")
-    book_show_parser.add_argument("--title", type=str, help="Show books by title (partial match)")
+    book_parser.add_argument("action_or_id", nargs="?", help="Book ID to show, 'add' to add book, or 'edit' to edit book")
+    book_parser.add_argument("edit_id", type=int, nargs="?", help="Book ID to edit (when action is 'edit')")
+    book_parser.add_argument("--author", type=str, help="Show books by specific author")
+    book_parser.add_argument("--year", type=int, help="Year to filter books")
+    book_parser.add_argument("--title", type=str, help="Show books by title (partial match)")
 
-    # Review management subcommands
+    # Review management command
     review_parser = subparsers.add_parser("review", help="Manage reviews")
-    review_parser.add_argument("id", type=int, nargs="?", help="Review ID to show (when no subcommand specified)")
-    review_subparsers = review_parser.add_subparsers(dest="review_action", help="Review actions")
-    
-    # Review add subcommand
-    review_add_parser = review_subparsers.add_parser("add", help="Add a review to existing book")
-    review_add_parser.add_argument("book_id", type=int, help="Book ID to add review to")
-    
-    # Review edit subcommand
-    review_edit_parser = review_subparsers.add_parser("edit", help="Edit review details")
-    review_edit_parser.add_argument("id", type=int, help="Review ID to edit")
-    
-    # Review show subcommand
-    review_show_parser = review_subparsers.add_parser("show", help="Show reviews")
-    review_show_parser.add_argument("id", type=int, nargs="?", help="Show specific review ID")
+    review_parser.add_argument("action_or_id", nargs="?", help="Review ID to show, 'add' to add review, or 'edit' to edit review")
+    review_parser.add_argument("target_id", type=int, nargs="?", help="Book ID to add review to (when action is 'add') or Review ID to edit (when action is 'edit')")
 
     # Import command with its specific arguments
     imp = subparsers.add_parser("import", help="Import books")

--- a/src/libro/main.py
+++ b/src/libro/main.py
@@ -1,10 +1,9 @@
 import sqlite3
 import sys
-import os
 from pathlib import Path
 
 from libro.config import init_args
-from libro.actions.show import show_book_detail, show_books_only
+from libro.actions.show import show_book_detail, show_books_only, show_recent_reviews
 from libro.actions.report import report
 from libro.actions.modify import add_book_review, add_book, add_review, edit_book, edit_review
 from libro.actions.db import init_db, migrate_db
@@ -51,8 +50,8 @@ def main():
             case "book":
                 book_action = args.get("book_action")
                 if book_action is None:
-                    # Show help for book command
-                    os.system("libro book --help")
+                    # Default to show action if no subcommand specified
+                    show_books_only(db, args)
                 else:
                     match book_action:
                         case "add":
@@ -66,8 +65,11 @@ def main():
             case "review":
                 review_action = args.get("review_action")
                 if review_action is None:
-                    # Show help for review command
-                    os.system("libro review --help")
+                    # Default to show action if no subcommand specified
+                    if args.get("id"):
+                        show_book_detail(db, args["id"])
+                    else:
+                        show_recent_reviews(db)
                 else:
                     match review_action:
                         case "add":

--- a/src/libro/main.py
+++ b/src/libro/main.py
@@ -76,8 +76,8 @@ def main():
             case "review":
                 action_or_id = args.get("action_or_id")
                 if action_or_id is None:
-                    # No argument - show recent reviews
-                    show_recent_reviews(db)
+                    # No argument - show recent reviews (or filtered reviews)
+                    show_recent_reviews(db, args)
                 elif action_or_id == "add":
                     # Add a review - need target_id (book_id)
                     target_id = args.get("target_id")

--- a/src/libro/main.py
+++ b/src/libro/main.py
@@ -48,41 +48,62 @@ def main():
             case "list":
                 manage_lists(db, args)
             case "book":
-                book_action = args.get("book_action")
-                if book_action is None:
-                    # Default to show action if no subcommand specified
+                action_or_id = args.get("action_or_id")
+                if action_or_id is None:
+                    # No argument - show recent books
                     show_books_only(db, args)
-                else:
-                    match book_action:
-                        case "add":
-                            add_book(db, args)
-                        case "edit":
-                            edit_book(db, args)
-                        case "show":
-                            show_books_only(db, args)
-                        case _:
-                            print("Book action not recognized")
-            case "review":
-                review_action = args.get("review_action")
-                if review_action is None:
-                    # Default to show action if no subcommand specified
-                    if args.get("id"):
-                        show_book_detail(db, args["id"])
+                elif action_or_id == "add":
+                    # Add a new book
+                    add_book(db, args)
+                elif action_or_id == "edit":
+                    # Edit a book - need edit_id
+                    edit_id = args.get("edit_id")
+                    if edit_id is None:
+                        print("Please specify a book ID to edit: libro book edit <book_id>")
                     else:
-                        show_recent_reviews(db)
+                        # Update args to use the edit_id as the main id
+                        args["id"] = edit_id
+                        edit_book(db, args)
                 else:
-                    match review_action:
-                        case "add":
-                            add_review(db, args)
-                        case "edit":
-                            edit_review(db, args)
-                        case "show":
-                            if args.get("id"):
-                                show_book_detail(db, args["id"])  # Same as default show
-                            else:
-                                print("Please specify a review ID: libro review show <review_id>")
-                        case _:
-                            print("Review action not recognized")
+                    # Try to parse as book ID
+                    try:
+                        book_id = int(action_or_id)
+                        args["id"] = book_id
+                        show_books_only(db, args)
+                    except ValueError:
+                        print(f"Unknown book action or invalid ID: {action_or_id}")
+                        print("Valid actions: add, edit, or a book ID number")
+            case "review":
+                action_or_id = args.get("action_or_id")
+                if action_or_id is None:
+                    # No argument - show recent reviews
+                    show_recent_reviews(db)
+                elif action_or_id == "add":
+                    # Add a review - need target_id (book_id)
+                    target_id = args.get("target_id")
+                    if target_id is None:
+                        print("Please specify a book ID to add review to: libro review add <book_id>")
+                    else:
+                        # Update args to use the target_id as book_id
+                        args["book_id"] = target_id
+                        add_review(db, args)
+                elif action_or_id == "edit":
+                    # Edit a review - need target_id (review_id)
+                    target_id = args.get("target_id")
+                    if target_id is None:
+                        print("Please specify a review ID to edit: libro review edit <review_id>")
+                    else:
+                        # Update args to use the target_id as the main id
+                        args["id"] = target_id
+                        edit_review(db, args)
+                else:
+                    # Try to parse as review ID
+                    try:
+                        review_id = int(action_or_id)
+                        show_book_detail(db, review_id)
+                    except ValueError:
+                        print(f"Unknown review action or invalid ID: {action_or_id}")
+                        print("Valid actions: add, edit, or a review ID number")
             case _:
                 print("Not yet implemented")
 


### PR DESCRIPTION

Remove the need for the "show" action when displaying for books and reviews.

The default is to show:

`libro book` - show recent books added
`libro review` - show recent reviews added

`libro book ID` - show book details for book ID
`libro review ID` - show review details for review ID

Improve consistency across all actions, book and review support same flags

`libro book --author NAME` - show books matching author NAME
`libro book --year YEAR` - show books published in YEAR
`libro book --title TITLE` - show books matching title TITLE

`libro review --author NAME` - show reviews matching author NAME
`libro review --year YEAR` - show reviews entered in YEAR
`libro review --title TITLE` - show reviews matching book title TITLE
